### PR TITLE
gitbug: Only query open issues

### DIFF
--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -83,7 +83,7 @@ class GitBugClient(Client):
 
     def get_issues(self) -> list[dict[str, Any]]:
         return self._query_graphql(
-            "{{ repository {{ allBugs {{ nodes {{ {} }} }} }} }}".format(
+            '{{ repository {{ allBugs(query: "status:open") {{ nodes {{ {} }} }} }} }}'.format(
                 " ".join(
                     [
                         "author { name }",
@@ -157,6 +157,9 @@ class GitBugService(Service[GitBugIssue]):
 
     def issues(self) -> Iterator[GitBugIssue]:
         for issue in self.client.get_issues():
+            # Guard against closed issues leaking through GraphQL query.
+            if issue.get("status") != "OPEN":
+                continue
             comments = issue.pop("comments")
             issue["description"] = comments["nodes"].pop(0)["message"]
 

--- a/tests/services/test_gitbug.py
+++ b/tests/services/test_gitbug.py
@@ -80,6 +80,40 @@ class TestGitBugIssue:
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
+    def test_issues_skips_closed(self, service, record):
+        closed_record = {**record, "status": "CLOSED"}
+        service.client.get_issues = mock.MagicMock(return_value=[closed_record])
+        issues = list(service.issues())
+
+        assert issues == []
+
+    def test_issues_mixed_open_closed(self, service, record):
+        closed_record = {**record, "status": "CLOSED"}
+        service.client.get_issues = mock.MagicMock(return_value=[closed_record, record])
+        issues = list(service.issues())
+
+        assert len(issues) == 1
+        assert (
+            TaskConstructor(issues[0]).get_taskwarrior_record()["gitbugid"]
+            == record["id"]
+        )
+
+
+class TestGitBugClient:
+    def test_get_issues_queries_open_bugs_only(self):
+        client = GitBugClient(
+            path=SERVICE_CONFIG["path"], port=43915, annotation_comments=False
+        )
+        with mock.patch.object(
+            GitBugClient,
+            "_query_graphql",
+            return_value={"repository": {"allBugs": {"nodes": []}}},
+        ) as query_graphql:
+            assert client.get_issues() == []
+
+        (query,), _ = query_graphql.call_args
+        assert 'allBugs(query: "status:open")' in query
+
 
 def test_home_path_expansion(tmp_path):
     # The path field is an ExpandedPath, so a configured tilde expands to the


### PR DESCRIPTION
Closes #1229.

---

Exclude closed git-bug issues from sync query, mirroring behavior of other bugwarrior services. This means issues that are closed in git-bug will complete the corresponding tasks in taskwarrior.

Filters for only open issues directly in GraphQL query so no closed issue should reach taskwarrior. Additionally adds small python condition to guard against git-bug upstream filter failures or query syntax drift.

Adds tests for individual closed issue and mixed open and closed issue querying, and a query builder test to avoid accidental syntax regressions.

---

Let me know if either the additional code-guard or the query builder test are unwanted, kept them as additional future insurance if upstream changes on their end or someone tries to change the query on ours.
